### PR TITLE
jsmaterialx package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,17 +269,17 @@ jobs:
         folder: javascript/MaterialXView/dist
         single-commit: true
 
-    - name: Upload Desktop Installed Package
+    - name: Upload Installed Package
       uses: actions/upload-artifact@v2
       with:
         name: MaterialX_${{ matrix.name }}
         path: build/installed/
 
-    - name: Upload Web Installed Package
+    - name: Upload JavaScript Package
       if: matrix.build_javascript == 'ON'
       uses: actions/upload-artifact@v2
       with:
-        name: JS_MaterialX_${{ matrix.name }}
+        name: MaterialX_JavaScript
         path: javascript/build/installed/JavaScript/MaterialX        
         if-no-files-found: ignore   
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -280,8 +280,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: JS_MaterialX_${{ matrix.name }}
-        path: |
-          javascript/build/installed/JavaScript/MaterialX        
+        path: javascript/build/installed/JavaScript/MaterialX        
         if-no-files-found: ignore   
 
     - name: Upload Reference Shaders

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -275,7 +275,7 @@ jobs:
         name: MaterialX_${{ matrix.name }}
         path: build/installed/
 
-   - name: Upload Web Installed Package
+    - name: Upload Web Installed Package
       if: matrix.build_javascript == 'ON'
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,11 +269,20 @@ jobs:
         folder: javascript/MaterialXView/dist
         single-commit: true
 
-    - name: Upload Installed Package
+    - name: Upload Desktop Installed Package
       uses: actions/upload-artifact@v2
       with:
         name: MaterialX_${{ matrix.name }}
         path: build/installed/
+
+   - name: Upload Web Installed Package
+      if: matrix.build_javascript == 'ON'
+      uses: actions/upload-artifact@v2
+      with:
+        name: JS_MaterialX_${{ matrix.name }}
+        path: |
+          javascript/build/installed/JavaScript/MaterialX        
+        if-no-files-found: ignore   
 
     - name: Upload Reference Shaders
       uses: actions/upload-artifact@v2

--- a/source/JsMaterialX/package.json
+++ b/source/JsMaterialX/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "jsmaterialx",
+  "version": "1.38.5",
+  "description": "JavaScript MaterialX Library",
+  "main": "JsMaterialXGenShader.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AcademySoftwareFoundation/MaterialX"
+  },
+  "sideEffects": false,
+  "files": [
+    "JsMaterialXCore.js",
+    "JsMaterialXCore.wasm",
+    "JsMaterialXGenShader.data",
+    "JsMaterialXGenShader.js",
+    "JsMaterialXGenShader.wasm",
+    "package.json"
+  ],
+  "keywords": [
+    "materialx",
+    "computer-graphics",
+    "vfx",
+    "3d-graphics",
+    "physically-based-rendering",
+    "real-time-rendering"
+  ],
+  "author": "ASWF",
+  "license": "Apache License 2.0",
+  "homepage": "https://www.materialx.org/"
+}


### PR DESCRIPTION
* Set up so that CI will upload an artifact for Javascript / WASM libraries
* Add a package.json wrapper to the install directory. This file can be used to publish to npm. (via `npm publish`).
These steps are not part of CI otherwise arbitrary PRs would publish.  A test publish ends up with a result like this:
![image](https://user-images.githubusercontent.com/49369885/167719375-7f89bd1b-bf1b-493c-8050-aff2c1f3b510.png)
