### PR TITLE
Update Usd docs and normalmapping support

### DIFF
--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -17,7 +17,7 @@
     <input name="specularColor" type="color3" value="0, 0, 0" uimin="0,0,0" uimax="1,1,1" 
            doc="Specular color to be used. Enabled when useSpecularWorkflow = 1. This is the color at 0 incidence. Edge color is assumed white. Transition between the two colors according to Schlick fresnel approximation."/>
     <input name="metallic" type="float" value="0" uimin="0.0" uimax="1.0" 
-           doc="Use 1 for metallic surfaces and 0 for non-metallic. Enabled when useSpecularWorkflow = 0. If metallic is 1, then both F0 (reflectivity at 0 degree incidence) and edge F90 reflectivity will simply be the Albedo."/>
+           doc="Use 1 for metallic surfaces and 0 for non-metallic. Enabled when useSpecularWorkflow = 0."/>
     <input name="roughness" type="float" value="0.5" uimin="0.0" uimax="1.0" 
            doc="Roughness for the specular lobe. The value ranges from 0 to 1, which goes from a perfectly specular surface at 0.0 to maximum roughness of the specular lobe."/>
     <input name="clearcoat" type="float" value="0" uimin="0.0" uimax="1.0" 
@@ -31,7 +31,7 @@
     <input name="ior" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" 
            doc="Index of Refraction to be used for translucent objects and objects with specular components, including the clearcoat if clearcoat > 0."/>
     <input name="normal" type="vector3" value="0, 0, 1" 
-           doc="Expects normal in tangent space [(-1,-1,-1), (1,1,1)]. This means your texture reader implementation should provide data to this node that is properly scaled and ready to be consumed as a tangent space normal."/>
+           doc="Expects normal in tangent space [(-1,-1,-1), (1,1,1)]."/>
     <input name="displacement" type="float" value="0" 
            doc="Displacement in the direction of the normal."/>
     <input name="occlusion" type="float" value="1" uimin="0.0" uimax="1.0" 

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -3,7 +3,6 @@
 
   <!-- ======================================================================== -->
   <!-- USD Preview Surface node definitions                                     -->
-  <!-- The following definitions are based on the specification defined here:   -->
   <!-- https://graphics.pixar.com/usd/release/spec_usdpreviewsurface.html       -->
   <!-- ======================================================================== -->
 
@@ -18,9 +17,9 @@
     <input name="specularColor" type="color3" value="0, 0, 0" uimin="0,0,0" uimax="1,1,1" 
            doc="Specular color to be used. Enabled when useSpecularWorkflow = 1. This is the color at 0 incidence. Edge color is assumed white. Transition between the two colors according to Schlick fresnel approximation."/>
     <input name="metallic" type="float" value="0" uimin="0.0" uimax="1.0" 
-           doc="Use 1 for metallic surfaces and 0 for non-metallic. Enabled when useSpecularWorkflow = 0. If metallic is 1, then both F0 (reflectivity at 0 degree incidence) and edge F90 reflectivity will simply be the Albedo. If metallic is 0, then Albedo is ignored in the calculation of F0 and F90; F0 is derived from ior via  and F90 is white. In between, we interpolate."/>
+           doc="Use 1 for metallic surfaces and 0 for non-metallic. Enabled when useSpecularWorkflow = 0. If metallic is 1, then both F0 (reflectivity at 0 degree incidence) and edge F90 reflectivity will simply be the Albedo."/>
     <input name="roughness" type="float" value="0.5" uimin="0.0" uimax="1.0" 
-           doc="Roughness for the specular lobe. The value ranges from 0 to 1, which goes from a perfectly specular surface at 0.0 to maximum roughness of the specular lobe. This value is usually squared before use with a GGX or Beckmann lobe. Note that roughness applies only to the specular lobe, and the transmissive lobe (if any) always assumes roughness 0.0."/>
+           doc="Roughness for the specular lobe. The value ranges from 0 to 1, which goes from a perfectly specular surface at 0.0 to maximum roughness of the specular lobe. This value is usually squared before use with a GGX or Beckmann lobe."/>
     <input name="clearcoat" type="float" value="0" uimin="0.0" uimax="1.0" 
            doc="Second specular lobe amount. The color is white."/>
     <input name="clearcoatRoughness" type="float" value="0.01" uimin="0.0" uimax="1.0" 

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -57,7 +57,7 @@
     <input name="st" type="vector2" defaultgeomprop="UV0" 
            doc="Texture coordinate to use to fetch this texture."/>
     <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
-           doc="Wrap mode when reading this texture. Possible Values: { black : Reader returns black outside unit square, clamp : extend edge values outside unit square, repeat : repeat texture outside unit square, mirror : flip and repeat texture outside unit square }"/>
+           doc="Wrap mode when reading this texture."/>
     <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
            doc="Wrap mode when reading this texture. Same options and caveats as wrapS."/>           
     <input name="fallback" type="color4" value="0, 0, 0, 1" 
@@ -80,7 +80,7 @@
     <input name="st" type="vector2" defaultgeomprop="UV0" 
            doc="Texture coordinate to use to fetch this texture."/>
     <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
-           doc="Wrap mode when reading this texture.Possible Values: { black : Reader returns black outside unit square, clamp : extend edge values outside unit square, repeat : repeat texture outside unit square, mirror : flip and repeat texture outside unit square }"/>
+           doc="Wrap mode when reading this texture."/>
     <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
            doc="Wrap mode when reading this texture. Same options and caveats as wrapS."/>
     <input name="fallback" type="vector3" value="0.5, 0.5, 1" 

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -54,19 +54,19 @@
   <nodedef name="ND_UsdUVTexture_23" node="UsdUVTexture" nodegroup="texture2d" version="2.3" isdefaultversion="true"
            doc="USD color texture reader version 2.3." >
     <input name="file" type="filename" uniform="true" 
-      doc="Path to the color texture."/>
+           doc="Path to the color texture."/>
     <input name="st" type="vector2" defaultgeomprop="UV0" 
-      doc="exture coordinate to use to fetch this texture. This node defines a mathematical/cartesian mapping from st to uv to image space: the (0, 0) st coordinate maps to a (0, 0) uv coordinate that samples the lower-left-hand corner of the texture image, as viewed on a monitor, while the (1, 1) st coordinate maps to a (1, 1) uv coordinate that samples the upper-right-hand corner of the texture image, as viewed on a monitor."/>
+           doc="exture coordinate to use to fetch this texture. This node defines a mathematical/cartesian mapping from st to uv to image space: the (0, 0) st coordinate maps to a (0, 0) uv coordinate that samples the lower-left-hand corner of the texture image, as viewed on a monitor, while the (1, 1) st coordinate maps to a (1, 1) uv coordinate that samples the upper-right-hand corner of the texture image, as viewed on a monitor."/>
     <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
-      doc="Wrap mode when reading this texture.Possible Values: { black : Reader returns black outside unit square, clamp : extend edge values outside unit square, repeat : repeat texture outside unit square, mirror : flip and repeat texture outside unit square }"/>
+           doc="Wrap mode when reading this texture.Possible Values: { black : Reader returns black outside unit square, clamp : extend edge values outside unit square, repeat : repeat texture outside unit square, mirror : flip and repeat texture outside unit square }"/>
     <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
-      doc="Wrap mode when reading this texture. Same options and caveats as wrapS."/>           
+           doc="Wrap mode when reading this texture. Same options and caveats as wrapS."/>           
     <input name="fallback" type="color4" value="0, 0, 0, 1" 
-      doc="Fallback value used when texture can not be read. Default is ( 0, 0, 0, 1 ) for color texture."/>
+           doc="Fallback value used when texture can not be read. Default is ( 0, 0, 0, 1 ) for color texture."/>
     <input name="scale" type="color4" value="1, 1, 1, 1" uniform="true" 
-      doc="Scale to be applied to all components of the texture. Output is textureValue * scale + bias. Default is (1, 1, 1, 1) for color texture."/>
+           doc="Scale to be applied to all components of the texture. Output is textureValue * scale + bias. Default is (1, 1, 1, 1) for color texture."/>
     <input name="bias" type="color4" value="0, 0, 0, 0" uniform="true" 
-      doc="Bias to be applied to all components of the texture. Output is textureValue * scale + bias. Default is (0, 0, 0, 0) for color texture."/>
+           doc="Bias to be applied to all components of the texture. Output is textureValue * scale + bias. Default is (0, 0, 0, 0) for color texture."/>
     <output name="r" type="float" />
     <output name="g" type="float" />
     <output name="b" type="float" />
@@ -77,19 +77,19 @@
   <nodedef name="ND_UsdUVTexture_23_NormalMap" node="UsdUvTexture" nodegroup="texture2d" version="2.3" isdefaultversion="true" 
            doc="USD normal map texture reader version 2.3.">
     <input name="file" type="filename" uniform="true" 
-      doc="Path to the normal map texture."/>
+           doc="Path to the normal map texture."/>
     <input name="st" type="vector2" defaultgeomprop="UV0" 
-      doc="exture coordinate to use to fetch this texture. This node defines a mathematical/cartesian mapping from st to uv to image space: the (0, 0) st coordinate maps to a (0, 0) uv coordinate that samples the lower-left-hand corner of the texture image, as viewed on a monitor, while the (1, 1) st coordinate maps to a (1, 1) uv coordinate that samples the upper-right-hand corner of the texture image, as viewed on a monitor."/>
+           doc="exture coordinate to use to fetch this texture. This node defines a mathematical/cartesian mapping from st to uv to image space: the (0, 0) st coordinate maps to a (0, 0) uv coordinate that samples the lower-left-hand corner of the texture image, as viewed on a monitor, while the (1, 1) st coordinate maps to a (1, 1) uv coordinate that samples the upper-right-hand corner of the texture image, as viewed on a monitor."/>
     <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
-      doc="Wrap mode when reading this texture.Possible Values: { black : Reader returns black outside unit square, clamp : extend edge values outside unit square, repeat : repeat texture outside unit square, mirror : flip and repeat texture outside unit square }"/>
+           doc="Wrap mode when reading this texture.Possible Values: { black : Reader returns black outside unit square, clamp : extend edge values outside unit square, repeat : repeat texture outside unit square, mirror : flip and repeat texture outside unit square }"/>
     <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
            doc="Wrap mode when reading this texture. Same options and caveats as wrapS."/>
     <input name="fallback" type="vector3" value="0.5, 0.5, 1" 
-          doc="Fallback value used when texture can not be read. Default is ( 0.5, 0.5, 1.0 ) for normal maps."/>
+           doc="Fallback value used when texture can not be read. Default is ( 0.5, 0.5, 1.0 ) for normal maps."/>
     <input name="scale" type="vector3" value="2, 2, 2" uniform="true" 
-      doc="Scale to be applied to all components of the texture. Output is textureValue * scale + bias. Default is (2, 2, 2) for normal maps"/>           
+           doc="Scale to be applied to all components of the texture. Output is textureValue * scale + bias. Default is (2, 2, 2) for normal maps"/>           
     <input name="bias" type="vector3" value="-1, -1, -1" uniform="true" 
-      doc="Bias to be applied to all components of the texture. Output is textureValue * scale + bias. Default is (-1, -1, 1) for normal maps"/>
+           doc="Bias to be applied to all components of the texture. Output is textureValue * scale + bias. Default is (-1, -1, 1) for normal maps"/>
     <output name="r" type="float" />
     <output name="g" type="float" />
     <output name="b" type="float" />

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -55,7 +55,7 @@
     <input name="file" type="filename" uniform="true" 
            doc="Path to the color texture."/>
     <input name="st" type="vector2" defaultgeomprop="UV0" 
-           doc="exture coordinate to use to fetch this texture. This node defines a mathematical/cartesian mapping from st to uv to image space: the (0, 0) st coordinate maps to a (0, 0) uv coordinate that samples the lower-left-hand corner of the texture image, as viewed on a monitor, while the (1, 1) st coordinate maps to a (1, 1) uv coordinate that samples the upper-right-hand corner of the texture image, as viewed on a monitor."/>
+           doc="Texture coordinate to use to fetch this texture."/>
     <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
            doc="Wrap mode when reading this texture. Possible Values: { black : Reader returns black outside unit square, clamp : extend edge values outside unit square, repeat : repeat texture outside unit square, mirror : flip and repeat texture outside unit square }"/>
     <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
@@ -78,7 +78,7 @@
     <input name="file" type="filename" uniform="true" 
            doc="Path to the normal map texture."/>
     <input name="st" type="vector2" defaultgeomprop="UV0" 
-           doc="Texture coordinate to use to fetch this texture. This node defines a mathematical/cartesian mapping from st to uv to image space: the (0, 0) st coordinate maps to a (0, 0) uv coordinate that samples the lower-left-hand corner of the texture image, as viewed on a monitor, while the (1, 1) st coordinate maps to a (1, 1) uv coordinate that samples the upper-right-hand corner of the texture image, as viewed on a monitor."/>
+           doc="Texture coordinate to use to fetch this texture."/>
     <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
            doc="Wrap mode when reading this texture.Possible Values: { black : Reader returns black outside unit square, clamp : extend edge values outside unit square, repeat : repeat texture outside unit square, mirror : flip and repeat texture outside unit square }"/>
     <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -19,23 +19,23 @@
     <input name="metallic" type="float" value="0" uimin="0.0" uimax="1.0" 
            doc="Use 1 for metallic surfaces and 0 for non-metallic. Enabled when useSpecularWorkflow = 0. If metallic is 1, then both F0 (reflectivity at 0 degree incidence) and edge F90 reflectivity will simply be the Albedo."/>
     <input name="roughness" type="float" value="0.5" uimin="0.0" uimax="1.0" 
-           doc="Roughness for the specular lobe. The value ranges from 0 to 1, which goes from a perfectly specular surface at 0.0 to maximum roughness of the specular lobe. This value is usually squared before use with a GGX or Beckmann lobe."/>
+           doc="Roughness for the specular lobe. The value ranges from 0 to 1, which goes from a perfectly specular surface at 0.0 to maximum roughness of the specular lobe."/>
     <input name="clearcoat" type="float" value="0" uimin="0.0" uimax="1.0" 
            doc="Second specular lobe amount. The color is white."/>
     <input name="clearcoatRoughness" type="float" value="0.01" uimin="0.0" uimax="1.0" 
            doc="Roughness for the second specular lobe."/>
     <input name="opacity" type="float" value="1" uimin="0.0" uimax="1.0" 
-           doc="When opacity is 1.0 then the gprim is fully opaque, if it is smaller than 1.0 then the prim is translucent, when it is 0 the gprim is transparent. Note that even a fully transparent object still receives lighting as, for example, perfectly clear glass still has a specular response."/>
+           doc="When opacity is 1.0 then the gprim is fully opaque, if it is smaller than 1.0 then the prim is translucent, when it is 0 the gprim is transparent."/>
     <input name="opacityThreshold" type="float" value="0" uimin="0.0" uimax="1.0" 
-           doc="The opacityThreshold input is useful for creating geometric cut-outs based on the opacity input. A value of 0.0 indicates that no masking is applied to the opacity input, while a value greater than 0.0 indicates that rendering of the surface is limited to the areas where the opacity is greater or equal to that value."/>
+           doc="The opacityThreshold input is useful for creating geometric cut-outs based on the opacity input."/>
     <input name="ior" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" 
            doc="Index of Refraction to be used for translucent objects and objects with specular components, including the clearcoat if clearcoat > 0."/>
     <input name="normal" type="vector3" value="0, 0, 1" 
-           doc="Expects normal in tangent space [(-1,-1,-1), (1,1,1)]. This means your texture reader implementation should provide data to this node that is properly scaled and ready to be consumed as a tangent space normal. The default input is ( 0,0,1 ) which allows for no transformation to be performed."/>
+           doc="Expects normal in tangent space [(-1,-1,-1), (1,1,1)]. This means your texture reader implementation should provide data to this node that is properly scaled and ready to be consumed as a tangent space normal."/>
     <input name="displacement" type="float" value="0" 
            doc="Displacement in the direction of the normal."/>
     <input name="occlusion" type="float" value="1" uimin="0.0" uimax="1.0" 
-           doc="Extra information about the occlusion of different parts of the mesh that this material is applied to. An occlusion value of 0.0 means the surface point is fully occluded by other parts of the surface, and a value of 1.0 means the surface point is completely unoccluded by other parts of the surface."/>
+           doc="Extra information about the occlusion of different parts of the mesh that this material is applied to."/>
     <output name="out" type="surfaceshader" />
   </nodedef>
 
@@ -59,7 +59,7 @@
     <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
            doc="Wrap mode when reading this texture."/>
     <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
-           doc="Wrap mode when reading this texture. Same options and caveats as wrapS."/>           
+           doc="Wrap mode when reading this texture."/>           
     <input name="fallback" type="color4" value="0, 0, 0, 1" 
            doc="Fallback value used when texture can not be read. Default is ( 0, 0, 0, 1 ) for color texture."/>
     <input name="scale" type="color4" value="1, 1, 1, 1" uniform="true" 
@@ -82,7 +82,7 @@
     <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
            doc="Wrap mode when reading this texture."/>
     <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
-           doc="Wrap mode when reading this texture. Same options and caveats as wrapS."/>
+           doc="Wrap mode when reading this texture."/>
     <input name="fallback" type="vector3" value="0.5, 0.5, 1" 
            doc="Fallback value used when texture can not be read. Default is ( 0.5, 0.5, 1.0 ) for normal maps."/>
     <input name="scale" type="vector3" value="2, 2, 2" uniform="true" 

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -32,11 +32,11 @@
     <input name="ior" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" 
            doc="Index of Refraction to be used for translucent objects and objects with specular components, including the clearcoat if clearcoat > 0."/>
     <input name="normal" type="vector3" value="0, 0, 1" 
-           doc="Expects normal in tangent space [(-1,-1,-1), (1,1,1)]. This means your texture reader implementation should provide data to this node that is properly scaled and ready to be consumed as a tangent space normal. The default input is ( 0,0,1 ) which allows for no transformation to be performed. This differs from the default for tangent space normalmap input which is ( 0.5, 0.5, 1 )."/>
+           doc="Expects normal in tangent space [(-1,-1,-1), (1,1,1)]. This means your texture reader implementation should provide data to this node that is properly scaled and ready to be consumed as a tangent space normal. The default input is ( 0,0,1 ) which allows for no transformation to be performed."/>
     <input name="displacement" type="float" value="0" 
            doc="Displacement in the direction of the normal."/>
     <input name="occlusion" type="float" value="1" uimin="0.0" uimax="1.0" 
-           doc="Extra information about the occlusion of different parts of the mesh that this material is applied to. Occlusion only makes sense as a surface-varying signal, and pathtracers will likely choose to ignore it. An occlusion value of 0.0 means the surface point is fully occluded by other parts of the surface, and a value of 1.0 means the surface point is completely unoccluded by other parts of the surface."/>
+           doc="Extra information about the occlusion of different parts of the mesh that this material is applied to. An occlusion value of 0.0 means the surface point is fully occluded by other parts of the surface, and a value of 1.0 means the surface point is completely unoccluded by other parts of the surface."/>
     <output name="out" type="surfaceshader" />
   </nodedef>
 

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -3,24 +3,40 @@
 
   <!-- ======================================================================== -->
   <!-- USD Preview Surface node definitions                                     -->
+  <!-- The following definitions are based on the specification defined here:   -->
+  <!-- https://graphics.pixar.com/usd/release/spec_usdpreviewsurface.html       -->
   <!-- ======================================================================== -->
 
   <!-- Node: UsdPreviewSurface -->
   <nodedef name="ND_UsdPreviewSurface_surfaceshader" node="UsdPreviewSurface" nodegroup="pbr" doc="USD preview surface shader" version="2.3" isdefaultversion="true">
-    <input name="diffuseColor" type="color3" value="0.18, 0.18, 0.18" uimin="0,0,0" uimax="1,1,1" />
-    <input name="emissiveColor" type="color3" value="0, 0, 0" uimin="0,0,0" uisoftmax="1,1,1" />
-    <input name="useSpecularWorkflow" type="integer" value="0" />
-    <input name="specularColor" type="color3" value="0, 0, 0" uimin="0,0,0" uimax="1,1,1" />
-    <input name="metallic" type="float" value="0" uimin="0.0" uimax="1.0" />
-    <input name="roughness" type="float" value="0.5" uimin="0.0" uimax="1.0" />
-    <input name="clearcoat" type="float" value="0" uimin="0.0" uimax="1.0" />
-    <input name="clearcoatRoughness" type="float" value="0.01" uimin="0.0" uimax="1.0" />
-    <input name="opacity" type="float" value="1" uimin="0.0" uimax="1.0" />
-    <input name="opacityThreshold" type="float" value="0" uimin="0.0" uimax="1.0" />
-    <input name="ior" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" />
-    <input name="normal" type="vector3" value="0, 0, 1" />
-    <input name="displacement" type="float" value="0" />
-    <input name="occlusion" type="float" value="1" uimin="0.0" uimax="1.0" />
+    <input name="diffuseColor" type="color3" value="0.18, 0.18, 0.18" uimin="0,0,0" uimax="1,1,1" 
+           doc="Diffuse color. When using metallic workflow this is interpreted as albedo."/>
+    <input name="emissiveColor" type="color3" value="0, 0, 0" uimin="0,0,0" uisoftmax="1,1,1" 
+           doc="Emissive component."/>
+    <input name="useSpecularWorkflow" type="integer" value="0" 
+           doc="This node can fundamentally operate in two modes : Specular workflow where you provide a texture/value to the specularColor input. Or, Metallic workflow where you provide a texture/value to the metallic input."/>
+    <input name="specularColor" type="color3" value="0, 0, 0" uimin="0,0,0" uimax="1,1,1" 
+           doc="Specular color to be used. Enabled when useSpecularWorkflow = 1. This is the color at 0 incidence. Edge color is assumed white. Transition between the two colors according to Schlick fresnel approximation."/>
+    <input name="metallic" type="float" value="0" uimin="0.0" uimax="1.0" 
+           doc="Use 1 for metallic surfaces and 0 for non-metallic. Enabled when useSpecularWorkflow = 0. If metallic is 1, then both F0 (reflectivity at 0 degree incidence) and edge F90 reflectivity will simply be the Albedo . If metallic is 0, then Albedo is ignored in the calculation of F0 and F90; F0 is derived from ior via  and F90 is white. In between, we interpolate."/>
+    <input name="roughness" type="float" value="0.5" uimin="0.0" uimax="1.0" 
+           doc="Roughness for the specular lobe. The value ranges from 0 to 1, which goes from a perfectly specular surface at 0.0 to maximum roughness of the specular lobe. This value is usually squared before use with a GGX or Beckmann lobe. Note that roughness applies only to the specular lobe, and the transmissive lobe (if any) always assumes roughness 0.0."/>
+    <input name="clearcoat" type="float" value="0" uimin="0.0" uimax="1.0" 
+           doc="Second specular lobe amount. The color is white."/>
+    <input name="clearcoatRoughness" type="float" value="0.01" uimin="0.0" uimax="1.0" 
+           doc="Roughness for the second specular lobe."/>
+    <input name="opacity" type="float" value="1" uimin="0.0" uimax="1.0" 
+           doc="When opacity is 1.0 then the gprim is fully opaque, if it is smaller than 1.0 then the prim is translucent, when it is 0 the gprim is transparent. Note that even a fully transparent object still receives lighting as, for example, perfectly clear glass still has a specular response."/>
+    <input name="opacityThreshold" type="float" value="0" uimin="0.0" uimax="1.0" 
+           doc="The opacityThreshold input is useful for creating geometric cut-outs based on the opacity input. A value of 0.0 indicates that no masking is applied to the opacity input, while a value greater than 0.0 indicates that rendering of the surface is limited to the areas where the opacity is greater or equal to that value."/>
+    <input name="ior" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" 
+           doc="ndex of Refraction to be used for translucent objects and objects with specular components, including the clearcoat if clearcoat > 0."/>
+    <input name="normal" type="vector3" value="0, 0, 1" 
+           doc="Expects normal in tangent space [(-1,-1,-1), (1,1,1)]. This means your texture reader implementation should provide data to this node that is properly scaled and ready to be consumed as a tangent space normal. The default input is ( 0,0,1 ) which allows for no transformation to be performed. This differs from the default for tangent space normalmap input which is ( 0.5, 0.5, 1 )."/>
+    <input name="displacement" type="float" value="0" 
+           doc="Displacement in the direction of the normal."/>
+    <input name="occlusion" type="float" value="1" uimin="0.0" uimax="1.0" 
+           doc="Extra information about the occlusion of different parts of the mesh that this material is applied to. Occlusion only makes sense as a surface-varying signal, and pathtracers will likely choose to ignore it. An occlusion value of 0.0 means the surface point is fully occluded by other parts of the surface, and a value of 1.0 means the surface point is completely unoccluded by other parts of the surface."/>
     <output name="out" type="surfaceshader" />
   </nodedef>
 
@@ -35,13 +51,20 @@
   </nodedef>
 
   <nodedef name="ND_UsdUVTexture_23" node="UsdUVTexture" nodegroup="texture2d" version="2.3" isdefaultversion="true">
-    <input name="file" type="filename" uniform="true" />
-    <input name="st" type="vector2" defaultgeomprop="UV0" />
-    <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" />
-    <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" />
-    <input name="fallback" type="color4" value="0, 0, 0, 1" />
-    <input name="scale" type="color4" value="1, 1, 1, 1" uniform="true" />
-    <input name="bias" type="color4" value="0, 0, 0, 0" uniform="true" />
+    <input name="file" type="filename" uniform="true" 
+      doc="Path to the color texture."/>
+    <input name="st" type="vector2" defaultgeomprop="UV0" 
+      doc="exture coordinate to use to fetch this texture. This node defines a mathematical/cartesian mapping from st to uv to image space: the (0, 0) st coordinate maps to a (0, 0) uv coordinate that samples the lower-left-hand corner of the texture image, as viewed on a monitor, while the (1, 1) st coordinate maps to a (1, 1) uv coordinate that samples the upper-right-hand corner of the texture image, as viewed on a monitor."/>
+    <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
+      doc="Wrap mode when reading this texture.Possible Values: { black : Reader returns black outside unit square, clamp : extend edge values outside unit square, repeat : repeat texture outside unit square, mirror : flip and repeat texture outside unit square }"/>
+    <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
+      doc="Wrap mode when reading this texture. Same options and caveats as wrapS."/>           
+    <input name="fallback" type="color4" value="0, 0, 0, 1" 
+      doc="Fallback value used when texture can not be read. Default is ( 0, 0, 0, 1 ) for color texture."/>
+    <input name="scale" type="color4" value="1, 1, 1, 1" uniform="true" 
+      doc="Scale to be applied to all components of the texture. Output is textureValue * scale + bias. Default is (1, 1, 1, 1) for color texture."/>
+    <input name="bias" type="color4" value="0, 0, 0, 0" uniform="true" 
+      doc="Bias to be applied to all components of the texture. Output is textureValue * scale + bias. Default is (0, 0, 0, 0) for color texture."/>
     <output name="r" type="float" />
     <output name="g" type="float" />
     <output name="b" type="float" />
@@ -50,13 +73,20 @@
   </nodedef>
 
   <nodedef name="ND_UsdUVTexture_23_NormalMap" node="UsdUvTexture" nodegroup="texture2d" version="2.3" isdefaultversion="true" >
-    <input name="file" type="filename" uniform="true" />
-    <input name="st" type="vector2" defaultgeomprop="UV0" />
-    <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" />
-    <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" />
-    <input name="fallback" type="vector3" value="0.5, 0.5, 1" />
-    <input name="scale" type="vector3" value="2, 2, 2" uniform="true" />
-    <input name="bias" type="vector3" value="-1, -1, -1" uniform="true" />
+    <input name="file" type="filename" uniform="true" 
+      doc="Path to the normal map texture."/>
+    <input name="st" type="vector2" defaultgeomprop="UV0" 
+      doc="exture coordinate to use to fetch this texture. This node defines a mathematical/cartesian mapping from st to uv to image space: the (0, 0) st coordinate maps to a (0, 0) uv coordinate that samples the lower-left-hand corner of the texture image, as viewed on a monitor, while the (1, 1) st coordinate maps to a (1, 1) uv coordinate that samples the upper-right-hand corner of the texture image, as viewed on a monitor."/>
+    <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
+      doc="Wrap mode when reading this texture.Possible Values: { black : Reader returns black outside unit square, clamp : extend edge values outside unit square, repeat : repeat texture outside unit square, mirror : flip and repeat texture outside unit square }"/>
+    <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
+           doc="Wrap mode when reading this texture. Same options and caveats as wrapS."/>
+    <input name="fallback" type="vector3" value="0.5, 0.5, 1" 
+          doc="Fallback value used when texture can not be read. Default is ( 0.5, 0.5, 1.0 ) for normal maps."/>
+    <input name="scale" type="vector3" value="2, 2, 2" uniform="true" 
+      doc="Scale to be applied to all components of the texture. Output is textureValue * scale + bias. Default is (2, 2, 2) for normal maps"/>           
+    <input name="bias" type="vector3" value="-1, -1, -1" uniform="true" 
+      doc="Bias to be applied to all components of the texture. Output is textureValue * scale + bias. Default is (-1, -1, 1) for normal maps"/>
     <output name="r" type="float" />
     <output name="g" type="float" />
     <output name="b" type="float" />

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -18,7 +18,7 @@
     <input name="specularColor" type="color3" value="0, 0, 0" uimin="0,0,0" uimax="1,1,1" 
            doc="Specular color to be used. Enabled when useSpecularWorkflow = 1. This is the color at 0 incidence. Edge color is assumed white. Transition between the two colors according to Schlick fresnel approximation."/>
     <input name="metallic" type="float" value="0" uimin="0.0" uimax="1.0" 
-           doc="Use 1 for metallic surfaces and 0 for non-metallic. Enabled when useSpecularWorkflow = 0. If metallic is 1, then both F0 (reflectivity at 0 degree incidence) and edge F90 reflectivity will simply be the Albedo . If metallic is 0, then Albedo is ignored in the calculation of F0 and F90; F0 is derived from ior via  and F90 is white. In between, we interpolate."/>
+           doc="Use 1 for metallic surfaces and 0 for non-metallic. Enabled when useSpecularWorkflow = 0. If metallic is 1, then both F0 (reflectivity at 0 degree incidence) and edge F90 reflectivity will simply be the Albedo. If metallic is 0, then Albedo is ignored in the calculation of F0 and F90; F0 is derived from ior via  and F90 is white. In between, we interpolate."/>
     <input name="roughness" type="float" value="0.5" uimin="0.0" uimax="1.0" 
            doc="Roughness for the specular lobe. The value ranges from 0 to 1, which goes from a perfectly specular surface at 0.0 to maximum roughness of the specular lobe. This value is usually squared before use with a GGX or Beckmann lobe. Note that roughness applies only to the specular lobe, and the transmissive lobe (if any) always assumes roughness 0.0."/>
     <input name="clearcoat" type="float" value="0" uimin="0.0" uimax="1.0" 
@@ -58,7 +58,7 @@
     <input name="st" type="vector2" defaultgeomprop="UV0" 
            doc="exture coordinate to use to fetch this texture. This node defines a mathematical/cartesian mapping from st to uv to image space: the (0, 0) st coordinate maps to a (0, 0) uv coordinate that samples the lower-left-hand corner of the texture image, as viewed on a monitor, while the (1, 1) st coordinate maps to a (1, 1) uv coordinate that samples the upper-right-hand corner of the texture image, as viewed on a monitor."/>
     <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
-           doc="Wrap mode when reading this texture.Possible Values: { black : Reader returns black outside unit square, clamp : extend edge values outside unit square, repeat : repeat texture outside unit square, mirror : flip and repeat texture outside unit square }"/>
+           doc="Wrap mode when reading this texture. Possible Values: { black : Reader returns black outside unit square, clamp : extend edge values outside unit square, repeat : repeat texture outside unit square, mirror : flip and repeat texture outside unit square }"/>
     <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
            doc="Wrap mode when reading this texture. Same options and caveats as wrapS."/>           
     <input name="fallback" type="color4" value="0, 0, 0, 1" 

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -14,7 +14,7 @@
     <input name="emissiveColor" type="color3" value="0, 0, 0" uimin="0,0,0" uisoftmax="1,1,1" 
            doc="Emissive component."/>
     <input name="useSpecularWorkflow" type="integer" value="0" 
-           doc="This node can fundamentally operate in two modes : Specular workflow where you provide a texture/value to the specularColor input. Or, Metallic workflow where you provide a texture/value to the metallic input."/>
+           doc="This node can fundamentally operate in two modes: Specular workflow where you provide a texture/value to the specularColor input. Or, Metallic workflow where you provide a texture/value to the metallic input."/>
     <input name="specularColor" type="color3" value="0, 0, 0" uimin="0,0,0" uimax="1,1,1" 
            doc="Specular color to be used. Enabled when useSpecularWorkflow = 1. This is the color at 0 incidence. Edge color is assumed white. Transition between the two colors according to Schlick fresnel approximation."/>
     <input name="metallic" type="float" value="0" uimin="0.0" uimax="1.0" 
@@ -30,7 +30,7 @@
     <input name="opacityThreshold" type="float" value="0" uimin="0.0" uimax="1.0" 
            doc="The opacityThreshold input is useful for creating geometric cut-outs based on the opacity input. A value of 0.0 indicates that no masking is applied to the opacity input, while a value greater than 0.0 indicates that rendering of the surface is limited to the areas where the opacity is greater or equal to that value."/>
     <input name="ior" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" 
-           doc="ndex of Refraction to be used for translucent objects and objects with specular components, including the clearcoat if clearcoat > 0."/>
+           doc="Index of Refraction to be used for translucent objects and objects with specular components, including the clearcoat if clearcoat > 0."/>
     <input name="normal" type="vector3" value="0, 0, 1" 
            doc="Expects normal in tangent space [(-1,-1,-1), (1,1,1)]. This means your texture reader implementation should provide data to this node that is properly scaled and ready to be consumed as a tangent space normal. The default input is ( 0,0,1 ) which allows for no transformation to be performed. This differs from the default for tangent space normalmap input which is ( 0.5, 0.5, 1 )."/>
     <input name="displacement" type="float" value="0" 
@@ -79,7 +79,7 @@
     <input name="file" type="filename" uniform="true" 
            doc="Path to the normal map texture."/>
     <input name="st" type="vector2" defaultgeomprop="UV0" 
-           doc="exture coordinate to use to fetch this texture. This node defines a mathematical/cartesian mapping from st to uv to image space: the (0, 0) st coordinate maps to a (0, 0) uv coordinate that samples the lower-left-hand corner of the texture image, as viewed on a monitor, while the (1, 1) st coordinate maps to a (1, 1) uv coordinate that samples the upper-right-hand corner of the texture image, as viewed on a monitor."/>
+           doc="Texture coordinate to use to fetch this texture. This node defines a mathematical/cartesian mapping from st to uv to image space: the (0, 0) st coordinate maps to a (0, 0) uv coordinate that samples the lower-left-hand corner of the texture image, as viewed on a monitor, while the (1, 1) st coordinate maps to a (1, 1) uv coordinate that samples the upper-right-hand corner of the texture image, as viewed on a monitor."/>
     <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 
            doc="Wrap mode when reading this texture.Possible Values: { black : Reader returns black outside unit square, clamp : extend edge values outside unit square, repeat : repeat texture outside unit square, mirror : flip and repeat texture outside unit square }"/>
     <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" 

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -34,7 +34,7 @@
     <output name="rgba" type="color4" />
   </nodedef>
 
-<nodedef name="ND_UsdUVTexture_23" node="UsdUVTexture" nodegroup="texture2d" version="2.3" isdefaultversion="true">
+  <nodedef name="ND_UsdUVTexture_23" node="UsdUVTexture" nodegroup="texture2d" version="2.3" isdefaultversion="true">
     <input name="file" type="filename" uniform="true" />
     <input name="st" type="vector2" defaultgeomprop="UV0" />
     <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" />
@@ -47,6 +47,21 @@
     <output name="b" type="float" />
     <output name="a" type="float" />
     <output name="rgb" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_UsdUVTexture_23_NormalMap" node="UsdUvTexture" nodegroup="texture2d" version="2.3" isdefaultversion="true" >
+    <input name="file" type="filename" uniform="true" />
+    <input name="st" type="vector2" defaultgeomprop="UV0" />
+    <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" />
+    <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" />
+    <input name="fallback" type="vector3" value="0.5, 0.5, 1" />
+    <input name="scale" type="vector3" value="2, 2, 2" uniform="true" />
+    <input name="bias" type="vector3" value="-1, -1, -1" uniform="true" />
+    <output name="r" type="float" />
+    <output name="g" type="float" />
+    <output name="b" type="float" />
+    <output name="a" type="float"  />
+    <output name="rgb" type="vector3" />
   </nodedef>
 
   <!-- Node: UsdPrimvarReader -->
@@ -307,6 +322,39 @@
     <output name="b" type="float" nodename="image_bias" channels="b" />
     <output name="a" type="float" nodename="image_bias" channels="a" />
     <output name="rgb" type="color3" nodename="image_bias" channels="rgb" />
+  </nodegraph>
+
+  <nodegraph name="IMP_UsdUVTexture_23_NormalMap" nodedef="ND_UsdUVTexture_23_NormalMap">
+    <input name="file" type="filename" uniform="true" value="" />
+    <input name="st" type="vector2" value="0, 0" />
+    <input name="wrapS" type="string" uniform="true" value="periodic" />
+    <input name="wrapT" type="string" uniform="true" value="periodic" />
+    <input name="fallback" type="vector3" value="0.5, 0.5, 1" />
+    <input name="scale" type="vector3" value="2, 2, 2" />
+    <input name="bias" type="vector3" value="-1, -1, -1" />
+    <image name="image" type="vector3" >
+      <input name="file" type="filename" uniform="true" interfacename="file" />
+      <input name="default" type="vector3" interfacename="fallback" value="0.5, 0.5, 1" />
+      <input name="texcoord" type="vector2" interfacename="st" value="0, 0" />
+      <input name="uaddressmode" type="string" uniform="true" interfacename="wrapS" value="periodic" />
+      <input name="vaddressmode" type="string" uniform="true" interfacename="wrapT" value="periodic" />
+    </image>
+    <add name="image_bias" type="vector3">
+      <input name="in1" type="vector3" nodename="image_scale" />
+      <input name="in2" type="vector3" interfacename="bias" value="-1, -1, -1" />
+    </add>
+    <multiply name="image_scale" type="vector3">
+      <input name="in1" type="vector3" nodename="image" />
+      <input name="in2" type="vector3" interfacename="scale" value="2, 2, 2" />
+    </multiply>
+    <constant name="constant" type="float">
+      <input name="value" type="float" value="1" />
+    </constant>
+    <output name="r" type="float" nodename="image_bias" channels="x" />
+    <output name="g" type="float" nodename="image_bias" channels="y"  />
+    <output name="b" type="float" nodename="image_bias" channels="z"  />
+    <output name="a" type="float" nodename="constant" />
+    <output name="rgb" type="vector3" nodename="image_bias" />
   </nodegraph>
 
   <!-- Node: UsdPrimvarReader -->

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -41,7 +41,8 @@
   </nodedef>
 
   <!-- Node: UsdUVTexture -->
-  <nodedef name="ND_UsdUVTexture" node="UsdUVTexture" nodegroup="texture2d" version="2.2" inherit="ND_UsdUVTexture_23">
+  <nodedef name="ND_UsdUVTexture" node="UsdUVTexture" nodegroup="texture2d" version="2.2" inherit="ND_UsdUVTexture_23" 
+           doc="USD texture reader version 2.2. Refer to 2.3 version for additional documentation. ">
     <output name="r" type="float" />
     <output name="g" type="float" />
     <output name="b" type="float" />
@@ -50,7 +51,8 @@
     <output name="rgba" type="color4" />
   </nodedef>
 
-  <nodedef name="ND_UsdUVTexture_23" node="UsdUVTexture" nodegroup="texture2d" version="2.3" isdefaultversion="true">
+  <nodedef name="ND_UsdUVTexture_23" node="UsdUVTexture" nodegroup="texture2d" version="2.3" isdefaultversion="true"
+           doc="USD color texture reader version 2.3." >
     <input name="file" type="filename" uniform="true" 
       doc="Path to the color texture."/>
     <input name="st" type="vector2" defaultgeomprop="UV0" 
@@ -72,7 +74,8 @@
     <output name="rgb" type="color3" />
   </nodedef>
 
-  <nodedef name="ND_UsdUVTexture_23_NormalMap" node="UsdUvTexture" nodegroup="texture2d" version="2.3" isdefaultversion="true" >
+  <nodedef name="ND_UsdUVTexture_23_NormalMap" node="UsdUvTexture" nodegroup="texture2d" version="2.3" isdefaultversion="true" 
+           doc="USD normal map texture reader version 2.3.">
     <input name="file" type="filename" uniform="true" 
       doc="Path to the normal map texture."/>
     <input name="st" type="vector2" defaultgeomprop="UV0" 

--- a/python/Scripts/mxdoc.py
+++ b/python/Scripts/mxdoc.py
@@ -63,7 +63,7 @@ def main():
                     infos.append('<b>'+ port.getName() + '</b>')
                 infos.append(port.getType())
                 val = port.getValue()
-                if port.getType() == "float":
+                if val and port.getType() == "float":
                     val = round(val, 6)
                 infos.append(str(val))
                 for attrname in ATTR_NAMES:
@@ -100,7 +100,7 @@ def main():
                     infos.append('**'+ port.getName() + '**')
                 infos.append(port.getType())
                 val = port.getValue()
-                if port.getType() == "float":
+                if val and port.getType() == "float":
                     val = round(val, 6)
                 infos.append(str(val))
                 for attrname in ATTR_NAMES:

--- a/resources/Materials/Examples/UsdPreviewSurface/usd_preview_normal_map.mtlx
+++ b/resources/Materials/Examples/UsdPreviewSurface/usd_preview_normal_map.mtlx
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <UsdUvTexture name="UsdUvTexture" type="multioutput" >
+    <input name="file" type="filename" uniform="true" value="../../../Images/brick_normal.jpg" />
+    <input name="st" type="vector2" nodename="place2d" />
+    <output name="r" type="float" />
+    <output name="g" type="float" />
+    <output name="b" type="float" />
+    <output name="a" type="float" />
+    <output name="rgb" type="vector3" />
+  </UsdUvTexture>
+  <UsdPreviewSurface name="UsdPreviewSurface" type="surfaceshader">
+    <input name="normal" type="vector3" nodename="UsdUvTexture" output="rgb" />
+  </UsdPreviewSurface>
+  <texcoord name="texcoord" type="vector2" />
+  <place2d name="place2d" type="vector2">
+    <input name="texcoord" type="vector2" nodename="texcoord" />
+    <input name="scale" type="vector2" value="0.5, 0.5" />
+  </place2d>
+  <surfacematerial name="USDPreview_NormalMap" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="UsdPreviewSurface" />
+  </surfacematerial>
+</materialx>


### PR DESCRIPTION
Update #1060

* Add docs from Pixar USD spec page. Add additional notation about normal input
* Add in normalmap version for UsdUvTexture along with new test case.
* Small fix to mxdoc documentation generator script.


