### PR TITLE
Fix parent / child assignment  logic fix

### DIFF
--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -605,7 +605,7 @@ export class Material
         // and assign to the associatged geometry. If there are no looks
         // then the first material is found and assignment to all the
         // geometry. 
-        while (this._materials.length) { this._materials.pop(); } 
+        this._materials.length = 0;
         this._defaultMaterial = null;
         var looks = doc.getLooks();
         if (looks.length)

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -605,7 +605,7 @@ export class Material
         // and assign to the associatged geometry. If there are no looks
         // then the first material is found and assignment to all the
         // geometry. 
-        this._materials = [];
+        while (this._materials.length) { this._materials.pop(); } 
         this._defaultMaterial = null;
         var looks = doc.getLooks();
         if (looks.length)
@@ -629,7 +629,15 @@ export class Material
                             }
                         }
                         let collection = materialAssign.getCollection();
+                        if (collection && collection && collection.charAt(0) == "/")
+                        {
+                            collection = collection.slice(1);
+                        }
                         let geom = materialAssign.getGeom();
+                        if (geom && geom && geom.charAt(0) == "/")
+                        {
+                            geom = geom.slice(1);
+                        }
                         let newAssignment;
                         if (collection || geom)
                         {

--- a/source/MaterialXCore/Look.cpp
+++ b/source/MaterialXCore/Look.cpp
@@ -29,7 +29,7 @@ vector<MaterialAssignPtr> getGeometryBindings(ConstNodePtr materialNode, const s
         {
             if (matAssign->getReferencedMaterial() == materialNode)
             {
-                if (geomStringsMatch(geom, matAssign->getActiveGeom()))
+                if (geomStringsMatch(matAssign->getActiveGeom(), geom, true))
                 {
                     matAssigns.push_back(matAssign);
                     continue;


### PR DESCRIPTION
Fix #1109 

## Change 
The matching logic (string) was "reversed" for membership so that parent assignments would  override child assignments. That is the logic should be to check if the path of the assignment is completely contained within the path to the geometry being tested.

e.g.
* The assignment string "/a/b" is contained in path to the geometry: "/a/b/c" so the material can be assigned to "/a/b/c"
* The assignment string "/a/b" is contained in path to the geometry: "/a/b" so the material can be assigned to "/a/b"
* The assignment string "/a/b/c" is not contained in path to the geometry: "/a/b" so the child's material cannot be assigned to the parent geometry.

## Desktop
![parent_child_assignment2](https://user-images.githubusercontent.com/49369885/197061645-fcd9dfeb-8c2c-489c-ba78-ee7419fb1c31.png)

## Web
![parent_child_assignment](https://user-images.githubusercontent.com/49369885/197061660-23a3b5b2-295d-43f7-a925-b627a99b9b9b.png)
