### PR TITLE
Support top level interface input

### DIFF
--- a/resources/Materials/TestSuite/stdlib/nodegraph_inputs/top_level_input.mtlx
+++ b/resources/Materials/TestSuite/stdlib/nodegraph_inputs/top_level_input.mtlx
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <surfacematerial name="surfacematerial" type="material" xpos="17.246376" ypos="-15.689655">
+    <input name="surfaceshader" type="surfaceshader" nodename="surface_unlit" />
+  </surfacematerial>
+  <input name="input_color3" type="color3" value="0, 0, 1" xpos="10.905797" ypos="-15.982759" />
+  <surface_unlit name="surface_unlit" type="surfaceshader" xpos="14.231884" ypos="-16.241379">
+    <input name="emission_color" type="color3" interfacename="input_color3" />
+  </surface_unlit>
+</materialx>

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -305,7 +305,7 @@ InputPtr Input::getInterfaceInput() const
 {
     if (hasInterfaceName())
     {
-        ConstNodeGraphPtr graph = getAncestorOfType<NodeGraph>();
+        ConstGraphElementPtr graph = getAncestorOfType<GraphElement>();
         if (graph)
         {
             return graph->getInput(getInterfaceName());

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -381,7 +381,17 @@ void ShaderNode::initialize(const Node& node, const NodeDef& nodeDef, GenContext
         ShaderInput* input = getInput(nodeValue->getName());
         if (input)
         {
-            input->setPath(nodeValue->getNamePath());
+            string path = nodeValue->getNamePath();
+            InputPtr nodeInput = nodeValue->asA<Input>();
+            if (nodeInput)
+            {
+                InputPtr interfaceInput = nodeInput->getInterfaceInput();
+                if (interfaceInput)
+                {
+                    path = interfaceInput->getNamePath();
+                }
+            }
+            input->setPath(path);
         }
     }
 


### PR DESCRIPTION
## Issue

Fix so that top level inputs are parsed properly and values and path reflection data is correct (for uniform updates).

### Defaults

Fix top level input discovery to include `GraphElement`s and not just `NodeGraph`s (a `Document` where top level inputs reside is a `GraphElement`).

Once discovered the proper value and path can be pulled from the interface. The path is important since global uniform update relies on path matching.

### Tests
Added in a simple top level test: `stdlib/nodegraph_inputs/top_level_input.mtlx`

Result in MaterialXView:
![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/01f8d6b9-422e-4e61-b61f-3fa537957bb1)
![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/70096e48-9ec1-4d13-b3ea-1510f231cdf3)

Result in MaterialX Graph Editor:
![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/15d2610d-82e5-48b3-a801-30192085f3c7)
![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/35d827d2-4e15-4fa5-8f09-44fe978d0a2e)
